### PR TITLE
[gitpod] run mvn clean install initially

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,10 @@
+tasks:
+  - init: ./mvnw clean install
+
+ports:
+  - port: 8080
+    onOpen: open-preview
+
 vscode:
   extensions:
     - vscjava.vscode-java-pack@0.8.1:LRImBn//d5JhH4PUEI1BaQ==

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,8 @@
+{
+   "files.exclude": {
+      "**/.classpath": true,
+      "**/.project": true,
+      "**/.settings": true,
+      "**/.factorypath": true
+   }
+}


### PR DESCRIPTION
This PR make gitpod initially run `mvn clean install`.  (saw your mention of this repo on twitter)

If you enable prebuilds on your repo, this is done on every push, so when someone opens a workspace maven has done its job already.

https://github.com/apps/gitpod-io

Also, I noticed that you are excluding all ide specific configuration from git. I guess that is on purpose so you don't pollute say IDEA users with vs-code config and vice versa. The downside of this approach is that users need to properly setup their tool everytime (and probably do it slightly different as well). So I'd recommend versioning things like workspace settings and launch configurations.